### PR TITLE
Fixed wrong Shebang

### DIFF
--- a/hyprshot
+++ b/hyprshot
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
It calls sh while it's a bash script. This change makes it compatible with systems that do not have bash set as the system shell.