### PR TITLE
Added -c/--current so use selected window/output option

### DIFF
--- a/hyprshot
+++ b/hyprshot
@@ -20,7 +20,8 @@ Options:
   -d, --debug           print debug information
   -s, --silent          don't send notification when screenshot is saved
   -r, --raw             output raw image data to stdout
-  -t, --notif-timeout         notification timeout in milliseconds (default 5000)
+  -t, --notif-timeout   notification timeout in milliseconds (default 5000)
+  -c, --current         select active window/output (not applicable to region)
   --clipboard-only      copy screenshot to clipboard and don't save image in disk
   -- [command]          open screenshot with a command of your choosing. e.g. hyprshot -m window -- mirage
 
@@ -87,13 +88,21 @@ function begin_grab() {
     local option=$1
     case $option in
         output)
-            local geometry=`grab_output`
+            if [ $CURRENT -eq 1 ]; then
+                local geometry=`grab_active_output`
+            else
+                local geometry=`grab_output`
+            fi
             ;;
         region)
             local geometry=`grab_region`
             ;;
         window)
-            local geometry=`grab_window`
+            if [ $CURRENT -eq 1 ]; then
+                local geometry=`grab_active_window`
+            else
+                local geometry=`grab_window`
+            fi
             ;;
     esac
     save_geometry "${geometry}"
@@ -101,6 +110,16 @@ function begin_grab() {
 
 function grab_output() {
     slurp -or
+}
+
+function grab_active_output() {
+    local active_workspace=`hyprctl -j activeworkspace`
+    local monitors=`hyprctl -j monitors`
+    Print "Monitors: %s\n" "$monitors"
+    Print "Active workspace: %s\n" "$active_workspace"
+    local current_monitor="$(echo $monitors | jq -r 'first(.[] | select(.activeWorkspace.id == '$(echo $active_workspace | jq -r '.id')'))')"
+    Print "Current output: %s\n" "$current_monitor"
+    echo $current_monitor | jq -r '"\(.x),\(.y) \(.width)x\(.height)"'
 }
 
 function grab_region() {
@@ -119,8 +138,15 @@ function grab_window() {
     slurp -r <<< "$boxes"
 }
 
+function grab_active_window() {
+    local active_window=`hyprctl -j activewindow`
+    local box=$(echo $active_window | jq -r '"\(.at[0]),\(.at[1]) \(.size[0])x\(.size[1])"')
+    Print "Box:\n%s\n" "$box"
+    echo "$box"
+}
+
 function args() {
-    local options=$(getopt -o hf:o:m:dsrt: --long help,filename:,output-folder:,mode:,clipboard-only,debug,silent,raw,notif-timeout: -- "$@")
+    local options=$(getopt -o hf:o:m:dsrt:c --long help,filename:,output-folder:,mode:,clipboard-only,debug,silent,raw,notif-timeout:,current -- "$@")
     eval set -- "$options"
 
     while true; do
@@ -157,6 +183,9 @@ function args() {
                 shift;
                 NOTIF_TIMEOUT=$1
                 ;;
+            -c | --current)
+                CURRENT=1
+                ;;
             --)
                 shift # Skip -- argument
                 COMMAND=${@:2}
@@ -181,6 +210,7 @@ DEBUG=0
 SILENT=0
 RAW=0
 NOTIF_TIMEOUT=5000
+CURRENT=0
 FILENAME="$(date +'%Y-%m-%d-%H%M%S_hyprshot.png')"
 [ -z "$HYPRSHOT_DIR" ] && SAVEDIR=${XDG_PICTURES_DIR:=~} || SAVEDIR=${HYPRSHOT_DIR}
 


### PR DESCRIPTION
Added -c / --current command-line option.
When mode is output, it's use geometry of monitor that has same activeWorkspace.id as id of active workspace from `hyprctl`.
When mode is window, id of active window is taken from `hyprctl` and it's geometry used.

Useful for binding keys in Hyprland