### PR TITLE
Force data type for wl-copy

### DIFF
--- a/hyprshot
+++ b/hyprshot
@@ -113,12 +113,12 @@ function save_geometry() {
         mkdir -p "$SAVEDIR"
         grim -g "${cropped_geometry}" "$SAVE_FULLPATH"
         output="$SAVE_FULLPATH"
-        wl-copy < "$output"
+        wl-copy --type image/png < "$output"
         [ -z "$COMMAND" ] || {
             "$COMMAND" "$output"
         }
     else
-        wl-copy < <(grim -g "${cropped_geometry}" -)
+        wl-copy --type image/png < <(grim -g "${cropped_geometry}" -)
     fi
 
     send_notification $output


### PR DESCRIPTION
Hi, this PR addresses the issue #28. Sometimes `wl-copy` can't infer copied data type and defaults to plain text. This PR changes this behavior, adding information about data type explicitly. 