### PR TITLE
Add -D,--delay option to allow setting a delay after selecting an area to screenshot.

### DIFF
--- a/hyprshot
+++ b/hyprshot
@@ -20,7 +20,7 @@ Options:
   -m, --mode                one of: output, window, region, active, OUTPUT_NAME
   -o, --output-folder       directory in which to save screenshot
   -f, --filename            the file name of the resulting screenshot
-  -D, --delay		    how long to delay taking the screenshot after selection
+  -D, --delay               how long to delay taking the screenshot after selection (seconds)
   -z, --freeze              freeze the screen on initialization
   -d, --debug               print debug information
   -s, --silent              don't send notification when screenshot is saved

--- a/hyprshot
+++ b/hyprshot
@@ -20,6 +20,7 @@ Options:
   -m, --mode                one of: output, window, region, active, OUTPUT_NAME
   -o, --output-folder       directory in which to save screenshot
   -f, --filename            the file name of the resulting screenshot
+  -D, --delay		    how long to delay taking the screenshot after selection
   -z, --freeze              freeze the screen on initialization
   -d, --debug               print debug information
   -s, --silent              don't send notification when screenshot is saved
@@ -168,6 +169,7 @@ function begin_grab() {
 	    geometry=`trim "${geometry}"`
             ;;
     esac
+    sleep ${DELAY:-0}
     save_geometry "${geometry}"
 }
 
@@ -232,7 +234,7 @@ function parse_mode() {
 }
 
 function args() {
-    local options=$(getopt -o hf:o:m:dszr:t: --long help,filename:,output-folder:,mode:,clipboard-only,debug,silent,freeze,raw,notif-timeout: -- "$@")
+    local options=$(getopt -o hf:o:m:D:dszr:t: --long help,filename:,output-folder:,mode:,delay:,clipboard-only,debug,silent,freeze,raw,notif-timeout: -- "$@")
     eval set -- "$options"
 
     while true; do
@@ -248,6 +250,10 @@ function args() {
             -f | --filename)
                 shift;
                 FILENAME=$1
+                ;;
+            -D | --delay)
+		shift;
+                DELAY=$1
                 ;;
             -m | --mode)
                 shift;

--- a/hyprshot
+++ b/hyprshot
@@ -169,7 +169,9 @@ function begin_grab() {
 	    geometry=`trim "${geometry}"`
             ;;
     esac
-    sleep ${DELAY:-0}
+    if [ ${DELAY} -gt 0 ] 2>/dev/null; then
+        sleep ${DELAY}
+    fi
     save_geometry "${geometry}"
 }
 


### PR DESCRIPTION
There are cases where something in the selected area/window has to be highlighted/hovered over with a mouse and window focus. The loss of focus during area/window selection means this can't be done. Adding a delay option means that the user has time to do this before a screenshot of the area is saved.

This pull request adds the `-D`/`--delay <time in seconds>` option to enable this. The delay takes place after selection, just before `save_geometry` is called.