### PR TITLE
Added a section to the README for Fedora to reflect it's availability in DNF

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Activate wayland overlay as described in [README](https://github.com/bsd-ac/wayl
 # emerge --ask gui-apps/hyprshot
 ```
 
+### Fedora
+As of Fedora 40:
+```bash
+# sudo dnf install hyprshot
+```
+
 ### Dependencies
 
 - hyprland (this one should be obvious)

--- a/README.md
+++ b/README.md
@@ -29,9 +29,13 @@ Activate wayland overlay as described in [README](https://github.com/bsd-ac/wayl
 ```
 
 ### Fedora
-As of Fedora 40:
+As of Fedora 40, hyprshot can be installed from the [Hyprland COPR Repository](https://copr.fedorainfracloud.org/coprs/solopasha/hyprland)
 ```bash
-# sudo dnf install hyprshot
+# enable the COPR if you have not already
+sudo dnf copr enable solopasha/hyprland
+
+# install hyprshot via DNF
+sudo dnf install hyprshot
 ```
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Activate wayland overlay as described in [README](https://github.com/bsd-ac/wayl
 ```
 
 ### Fedora
-As of Fedora 40, hyprshot can be installed from the [Hyprland COPR Repository](https://copr.fedorainfracloud.org/coprs/solopasha/hyprland)
+As of Fedora 43, hyprshot can be installed from the [Hyprland COPR Repository](https://copr.fedorainfracloud.org/coprs/solopasha/hyprland)
 ```bash
 # enable the COPR if you have not already
 sudo dnf copr enable solopasha/hyprland


### PR DESCRIPTION
In searching for a screenshot tool for my hyprland installed on Fedora 40, I saw hyprshot recommended as a tool, and decided it fit my needs perfectly. I went to install it using your manual installation instructions only to find v1.30 available in the Fedora Repositories.

To help future fedora users who may choose to install this utility, I wanted to update the documentation accordingly.

It may also help to add a table of known Linux Distros/BSD/Unix/etc where hyprshot is included in the distros repositories. See for example the screenshot taken from [Waybar Repo](https://github.com/Alexays/Waybar) below. I chose not to add that in this PR so it could be discussed
![image](https://github.com/user-attachments/assets/49f832b5-638c-45a1-93ea-7d4599dc9712)