### PR TITLE
replace grim with wayshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Activate wayland overlay as described in [README](https://github.com/bsd-ac/wayl
 
 - hyprland (this one should be obvious)
 - jq (to parse and manipulate json)
-- grim (to take the screenshot)
+- wayshot (to take the screenshot)
 - slurp (to select what to screenshot)
 - wl-clipboard (to copy screenshot to clipboard)
 - libnotify (to get notified when a screenshot is saved)

--- a/hyprshot
+++ b/hyprshot
@@ -111,20 +111,20 @@ function save_geometry() {
     local output=""
 
     if [ $RAW -eq 1 ]; then
-        grim -g "${geometry}" -
+        wayshot -s "${geometry}" --stdout
         return 0
     fi
 
     if [ $CLIPBOARD -eq 0 ]; then
         mkdir -p "$SAVEDIR"
-        grim -g "${geometry}" "$SAVE_FULLPATH"
+        wayshot -s "${geometry}" -f "$SAVE_FULLPATH"
         output="$SAVE_FULLPATH"
         wl-copy --type image/png < "$output"
         [ -z "$COMMAND" ] || {
             "$COMMAND" "$output"
         }
     else
-        wl-copy --type image/png < <(grim -g "${geometry}" -)
+        wl-copy --type image/png < <(wayshot -s "${geometry}" --stdout)
     fi
 
     send_notification $output


### PR DESCRIPTION
Grim takes more than half a second on my machine when taking a full screen screenshot, so I replaced its use with wayshot

| command                                        | user  | system | cpu | total |
| ---------------------------------------------- | ----- | ------ | --- | ----- |
| grim -g '0,0 3440x1440' \| wl-copy             | 0.62s | 0.00s  | 98% | 0.635 |
| wayshot -s '0,0 3440x1440' --stdout \| wl-copy | 0.03s | 0.01s  | 70% | 0.057 |