### PR TITLE
Only kill hyprpicker if running

### DIFF
--- a/hyprshot
+++ b/hyprshot
@@ -134,7 +134,9 @@ function checkRunning() {
     sleep 1
     while [[ 1 == 1 ]]; do
         if [[ $(pgrep slurp | wc -m) == 0 ]]; then
-            pkill hyprpicker
+            if [ $FREEZE -eq 1 ]; then
+                pkill hyprpicker
+            fi
             exit
         fi
     done


### PR DESCRIPTION
If Hyprshot is not in --freeze mode, then the hyprpicker process will not exist. This causes it to not quit properly when a screenshot is taken. 