### PR TITLE
fix race condition between slurp and hyprpicker

### DIFF
--- a/hyprshot
+++ b/hyprshot
@@ -142,9 +142,10 @@ function checkRunning() {
 
 function begin_grab() {
     if [ $FREEZE -eq 1 ] && [ "$(command -v "hyprpicker")" ] >/dev/null 2>&1; then
-        hyprpicker -r -z &
-        sleep 0.2
-        HYPRPICKER_PID=$!
+        while ! pgrep -x "hyprpicker" > /dev/null; do
+            hyprpicker -r -z &
+            HYPRPICKER_PID=$!
+        done
     fi
     local option=$1
     case $option in


### PR DESCRIPTION
with the previous sleep method, it is possible for hyprpicker to take longer than 0.2s to open which results in slurp being opened without hyprpicker being below slurp
replacing it fixes this
(this recording was done on sway(fx). however i was able to reproduce it on hyprland too)

https://github.com/user-attachments/assets/81dbf8ab-57b7-491b-ba38-f83c124b95f4

