### PR TITLE
Fixed issue operation cancellation caused notifications to be sent and clipboard to be wiped

### DIFF
--- a/hyprshot
+++ b/hyprshot
@@ -110,6 +110,10 @@ function save_geometry() {
     local geometry="${1}"
     local output=""
 
+    if ! grep -Pq '^\d+,\d+\s+\d+x\d+$' <<< "$geometry"; then
+        return 1
+    fi
+
     if [ $RAW -eq 1 ]; then
         grim -g "${geometry}" -
         return 0


### PR DESCRIPTION
# Fixed issue operation cancellation caused notifications to be sent and  clipboard to be wiped 
## How to replicate Issue
### Notification Issue
1. type any command to take a screenshot
2. Press `escape` to cancel the screenshot
3. Notice how notifications are still being sent suggesting a successful screenshot even when the operation is cancelled

### Clipboard Issue
1. Take a screenshot normally
2. Take a screenshot but cancel the operation (Do not select a region/window)
3. Notice how the cancelled operation overwrote the previous screenshot in the clipboard

## Fix 
updated the `save_geometry()` function to check if the `geometry` variable has been updated by slurp

```bash
function save_geometry() {
    ...   
    # I noticed that the geometry variable is passed to this function after it has been captured by slurp
    # grim expects the geometry variable to be in a certain format, e.g. "10,20 300x400" 
    # this statement simply checks if the geometry variable follows the regex format that grim expects
    # the geometry variable is not always empty, sometimes it is "   ,   x   "  thus regex matching is used rather 
    # than checking if the string is empty   

    if ! grep -Pq '^\d+,\d+\s+\d+x\d+$' <<< "$geometry"; then
        return 1
    fi
    ...
}
``` 
This fix greatly improves on my previous submission where I checked if the `grim` commands were successful which introduced more complexity rather than simply checking the  reason for failure

## This fix addresses the following issues
- [Issue 42](https://github.com/Gustash/Hyprshot/issues/42)
- [Issue 78](https://github.com/Gustash/Hyprshot/issues/78)
- [Issue 79]( https://github.com/Gustash/Hyprshot/issues/79) 

